### PR TITLE
Include current environment variables for child processess

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ app.isChanged = false;
 
 app.defaultOptions = {
 	path: '',
-	env: { NODE_ENV: 'development' },
+	env: _.extend({ NODE_ENV: 'development' }, process.env),
 	execArgv: [],
 	delay: 600,
 	successMessage: /^server listening$/,


### PR DESCRIPTION
When using this module in Mac/Windows with a node app that spawns child processes, those processes lose all their environment variables unless passed explicitly.
Extending over `NODE_ENV` also ensures the proper value in case a user has it defined as a system-wide environment variable.
